### PR TITLE
Added header fix for instructional-events API

### DIFF
--- a/today-classes-node/microservice/src/today-classes.js
+++ b/today-classes-node/microservice/src/today-classes.js
@@ -57,7 +57,12 @@ async function getInstructionalEvents({apiKey, context, sectionIds}) {
             apiKey,
             context,
             resource: 'instructional-events',
-            searchParams
+            searchParams,
+            options: {
+                headers: {
+                    'Accept': `application/vnd.hedtech.integration.${instructionalEventsVersion}+json`
+                }
+            }
         });
     });
 


### PR DESCRIPTION
For instructional-events API, we need to provide the ability to dynamic set the header version based on the `RESOURCE_INSTRUCTIONAL_EVENTS_VERSION` environment variable version.